### PR TITLE
Change 'mark' command to be case-sensitive

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -132,7 +132,7 @@ Updates an applicant's status as specified.
 
 Format: `mark NAME status/STATUS`
 
-* `NAME` is case-insensitive. e.g. `john doe` and `John Doe` will update the same applicant's status.
+* `NAME` is case-sensitive. e.g. `john doe` and `John Doe` will update separate applicants' statuses.
 * `STATUS` is case-insensitive. e.g. `accepted` and `ACCEPTED` will both update the applicant's status to `"Accepted"`.
 * Note: Possible statuses are `ACCEPTED`, `REJECTED` or `PENDING`.
 

--- a/src/main/java/seedu/address/logic/commands/MarkApplicantStatusCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkApplicantStatusCommand.java
@@ -47,7 +47,7 @@ public class MarkApplicantStatusCommand extends Command {
 
         Applicant applicantToUpdate;
         try {
-            applicantToUpdate = model.getApplicantByNameIgnoreCase(name);
+            applicantToUpdate = model.getApplicantByName(name);
         } catch (ApplicantNotFoundException e) {
             throw new CommandException(String.format(MESSAGE_NO_SUCH_APPLICANT_WITH_NAME, name));
         }

--- a/src/main/java/seedu/address/model/ApplicantBook.java
+++ b/src/main/java/seedu/address/model/ApplicantBook.java
@@ -78,9 +78,9 @@ public class ApplicantBook implements ReadOnlyApplicantBook {
     /**
      * Returns the applicant with the specified name, if any.
      */
-    public Applicant getApplicantByNameIgnoreCase(Name applicantName) {
+    public Applicant getApplicantByName(Name applicantName) {
         requireNonNull(applicantName);
-        return applicants.getApplicantByNameIgnoreCase(applicantName);
+        return applicants.getApplicantByName(applicantName);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -59,7 +59,7 @@ public interface Model {
     /**
      * Returns the applicant with the specified name, if any.
      */
-    Applicant getApplicantByNameIgnoreCase(Name applicantName);
+    Applicant getApplicantByName(Name applicantName);
 
 
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -286,9 +286,9 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public Applicant getApplicantByNameIgnoreCase(Name applicantName) {
+    public Applicant getApplicantByName(Name applicantName) {
         requireNonNull(applicantName);
-        return applicantBook.getApplicantByNameIgnoreCase(applicantName);
+        return applicantBook.getApplicantByName(applicantName);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/applicant/Applicant.java
+++ b/src/main/java/seedu/address/model/applicant/Applicant.java
@@ -145,15 +145,6 @@ public class Applicant {
     }
 
     /**
-     * Returns true if this applicant has the specified name.
-     * Case-insensitive comparison.
-     */
-    public boolean hasNameIgnoreCase(Name name) {
-        requireNonNull(name);
-        return this.name.equalsIgnoreCase(name);
-    }
-
-    /**
      * Returns true if this applicant has the given application status.
      */
     public boolean hasApplicationStatus(ApplicationStatus applicationStatus) {

--- a/src/main/java/seedu/address/model/applicant/UniqueApplicantList.java
+++ b/src/main/java/seedu/address/model/applicant/UniqueApplicantList.java
@@ -54,10 +54,10 @@ public class UniqueApplicantList implements Iterable<Applicant> {
      * Returns the applicant in the list with the specified name, if any.
      * @throws ApplicantNotFoundException if not found.
      */
-    public Applicant getApplicantByNameIgnoreCase(Name name) {
+    public Applicant getApplicantByName(Name name) {
         requireNonNull(name);
         return internalList.stream()
-                .filter(applicant -> applicant.hasNameIgnoreCase(name))
+                .filter(applicant -> applicant.hasName(name))
                 .findFirst()
                 .orElseThrow(ApplicantNotFoundException::new);
     }

--- a/src/test/java/seedu/address/logic/commands/AddPositionCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddPositionCommandTest.java
@@ -118,7 +118,7 @@ public class AddPositionCommandTest {
         }
 
         @Override
-        public Applicant getApplicantByNameIgnoreCase(Name applicantName) {
+        public Applicant getApplicantByName(Name applicantName) {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
Closes #163.

### Current
`mark sally` will simply mark the first occurrence of `sally` in the list, so if we have:
1. sally
2. Sally

It is currently not possible to update item 2. 

### Fix
Changed behaviour of command to do case-sensitive name matching.